### PR TITLE
fix import python-magic fail in win32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 requests
 BeautifulSoup4
-python-magic
-python-magic-bin; platform_system=='Windows'
+python-magic; sys_platform == 'darwin'
+python-magic; sys_platform == 'linux'
+python-magic-bin; sys_platform == 'win32'
 markdown2[all]
 natsort


### PR DESCRIPTION
python-magic without platform limit will cause pip install both `python-magic` and `python-magic-bin` in win32. we should limit it in darwin and linux.
more detail see: https://t.me/trilium_cn/510