### PR TITLE
Personalized ToDo caption

### DIFF
--- a/src/trilium_py/client.py
+++ b/src/trilium_py/client.py
@@ -605,8 +605,9 @@ class ETAPI:
         """uncheck a todo"""
         return self.todo_check(todo_index, check=False)
 
-    def add_todo(self, todo_description):
+    def add_todo(self, todo_description: str, todo_caption: str = r'<p>TODO:</p>') -> bool:
         """append item to todo list"""
+
         todo_description = todo_description.strip()
         try:
             content = self.get_today_note_content()
@@ -628,7 +629,7 @@ class ETAPI:
 
             if not todo_labels:
                 logger.info('new empty page')
-                todo_item_html = f'''<p>TODO:</p><ul class="todo-list">{todo_item_html}</ul>'''
+                todo_item_html = todo_caption + f'<ul class="todo-list">{todo_item_html}</ul>'
                 todo_item = BeautifulSoup(todo_item_html, 'html.parser')
                 soup.insert(0, todo_item)
             else:

--- a/src/trilium_py/utils/markdown_math.py
+++ b/src/trilium_py/utils/markdown_math.py
@@ -49,7 +49,7 @@ def sanitizeInput(
     inline_delims = inline_delims or ["$", "$"]
     equation_delims = equation_delims or ["$$", "$$"]
 
-    #Check placeholder is valid.
+    # Check placeholder is valid.
     if not markdown_safe(placeholder):
         raise ValueError("Placeholder %s altered by markdown processing." % placeholder)
     # really what we want is a reverse markdown function, but as that's too much work, this will do
@@ -151,8 +151,8 @@ def reconstructMath(
     anyone is already doing this, there already formatted text might be mangled (I think I've taken
     steps to make sure it won't but not extensively tested...)
     """
-    inline_delims = inline_delims or ['<span class="math-tex">\(', '\)</span>']
-    equation_delims = equation_delims or ['<span class="math-tex">\[', '\]</span>']
+    inline_delims = inline_delims or ['<span class="math-tex">\\(', '\\)</span>']
+    equation_delims = equation_delims or ['<span class="math-tex">\\[', '\\]</span>']
 
     delims = [['', ''], inline_delims, equation_delims]
     placeholder_re = re.compile("(?<!\\\\)" + re.escape(placeholder))

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -1,0 +1,39 @@
+import re
+import unittest
+
+import requests_mock
+
+from trilium_py.client import ETAPI
+
+
+class TestToDo(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.etapi = ETAPI('mock://bogus:8080')
+        self.day_url = re.compile(
+            r'mock://bogus:8080/etapi/calendar/days/[0-9]{4}-[0-9]{2}-[0-9]{2}'
+        )
+        self.content_url = 'mock://bogus:8080/etapi/notes/deadbeef/content'
+
+    def test_todo_add(self):
+        with requests_mock.Mocker() as mock:
+            mock.register_uri('GET', self.day_url, json={"noteId": "deadbeef"})
+            mock.get(self.content_url, text="<p></p>")
+            adapter = mock.put(self.content_url, status_code=204)
+
+            result = self.etapi.add_todo('item_1')
+            text = '<p>TODO:</p><ul class="todo-list"><li><label class="todo-list__label"><input disabled="disabled" type="checkbox"/><span class="todo-list__label__description">item_1</span></label></li></ul><p></p>'
+            self.assertEqual(adapter.last_request.text, text)
+            self.assertTrue(result)
+
+    def test_todo_add_h3(self):
+        with requests_mock.Mocker() as mock:
+            mock.register_uri('GET', self.day_url, json={"noteId": "deadbeef"})
+            mock.get(self.content_url, text="<p></p>")
+            adapter = mock.put(self.content_url, status_code=204)
+
+            result = self.etapi.add_todo('item_1', todo_caption='<h3>To Do</h3>')
+            text = '<h3>To Do</h3><ul class="todo-list"><li><label class="todo-list__label"><input disabled="disabled" type="checkbox"/><span class="todo-list__label__description">item_1</span></label></li></ul><p></p>'
+            self.assertEqual(adapter.last_request.text, text)
+            self.assertTrue(result)


### PR DESCRIPTION
I use the [Blue theme](https://github.com/SiriusXT/trilium-theme-blue) and wanted the `To Do` caption to show up as a header. So I added an optional argument to add_todo() for that use case.

test_todo.py provides an example of unit testing this kind of change.