### PR TITLE
Update client.py

### DIFF
--- a/src/trilium_py/client.py
+++ b/src/trilium_py/client.py
@@ -825,7 +825,7 @@ class ETAPI:
                         no_latex_part,
                         extras=['fenced-code-blocks', 'strike', 'tables', 'task_list'],
                     ),
-                    latex_code_part,
+                    list(map(lambda x : x.replace("<"," \lt ").replace(">"," \gt "),latex_code_part))
                 )
         note_id = ''
 


### PR DESCRIPTION
Fixed a tiny bug
If there is a "<" or ">" symbol in the latex code it may be displayed incorrectly, so it is replaced with the standard latex code