### PR TITLE
Add error handling for export notes, no longer outputs file on error.

### DIFF
--- a/src/trilium_py/client.py
+++ b/src/trilium_py/client.py
@@ -520,10 +520,13 @@ class ETAPI:
             "format": format,
         }
         r = requests.get(url, params=clean_param(params), headers=self.get_header())
-        logger.info(r.status_code)
-        with open(savePath, 'wb') as fd:
-            for chunk in r.iter_content(chunk_size=chunk_size):
-                fd.write(chunk)
+        if r:
+            logger.info(r.status_code)
+            with open(savePath, 'wb') as fd:
+                for chunk in r.iter_content(chunk_size=chunk_size):
+                    fd.write(chunk)
+        else:
+            logger.error(r.status_code)
         return True
 
     def get_today_note_content(self):


### PR DESCRIPTION
This makes it to where it won't create a exported note zip if there is a 404 or other error.