### PR TITLE
Add 'utcDateCreated' to patch_note()

### DIFF
--- a/src/trilium_py/client.py
+++ b/src/trilium_py/client.py
@@ -366,7 +366,8 @@ class ETAPI:
         return res.json()
     
     def format_date(self, date: datetime) -> str:
-        return date.strftime('%Y-%m-%d %H:%M:%S%Z')
+        # note: ETAPI requires exactly 3 decimal places for seconds
+        return date.strftime('%Y-%m-%d %H:%M:%S.%d3%Z')
 
     def delete_note(self, noteId: str) -> bool:
         url = f'{self.server_url}/etapi/notes/{noteId}'

--- a/src/trilium_py/client.py
+++ b/src/trilium_py/client.py
@@ -5,6 +5,7 @@ import sys
 import urllib.parse
 from collections.abc import Mapping
 from typing import Optional, Union
+from datetime import datetime
 
 import magic
 import markdown2
@@ -349,15 +350,23 @@ class ETAPI:
         title: Optional[str] = None,
         type: Optional[str] = None,
         mime: Optional[str] = None,
+        utcDateCreated: Optional[datetime] = None,
     ) -> dict:
         url = f'{self.server_url}/etapi/notes/{noteId}'
+
+        utcDateCreated = self.format_date(utcDateCreated) if utcDateCreated else None
+        
         params = {
             "title": title,
             "type": type,
             "mime": mime,
+            "utcDateCreated": utcDateCreated,
         }
         res = requests.patch(url, json=clean_param(params), headers=self.get_header())
         return res.json()
+    
+    def format_date(self, date: datetime) -> str:
+        return date.strftime('%Y-%m-%d %H:%M:%S%Z')
 
     def delete_note(self, noteId: str) -> bool:
         url = f'{self.server_url}/etapi/notes/{noteId}'


### PR DESCRIPTION
spawned from https://github.com/orgs/TriliumNext/discussions/169, the most significant part being:

> zadam: I've added the possibility to specify dateCreated and utcDateCreated to the ETAPI. The modification date is still generated automatically. -- from https://github.com/zadam/trilium/issues/4199