### PR TITLE
Add functions to ensure titles are legal filenames

### DIFF
--- a/examples/turtl-to-markdown/main.py
+++ b/examples/turtl-to-markdown/main.py
@@ -16,6 +16,16 @@ def make_dir(p):
 def decode(s):
     return base64.b64decode(s)
 
+def strip_illegal_characters(s):
+    illegal_chars = [r"/", "\\", "<", ">", ":", "\"", "|", "?", "*"]
+    out_string = s
+    for char in illegal_chars:
+        out_string = r'{}'.format(out_string).replace(char, '')
+    return out_string
+    
+def truncate_long_filenames(s):
+	out_string = s[:250]
+	return out_string
 
 make_dir(output)
 
@@ -52,6 +62,11 @@ for x in d['notes']:
         # give a default name if no title exists
         title = f'No title {counter}'
         counter += 1
+        
+    title = strip_illegal_characters(title)
+    
+    if len(title) > 250:
+        title = truncate_long_filenames(title)
 
     if not board_id:
         # root folder if not belong to board


### PR DESCRIPTION
I had to add this code to get my own stuff exported from Turtl; most of it was due to OSError exceptions for filenames that were too long or contained illegal characters,

Characters not legal to have in filenames are stripped out and filenames are truncated to 250 chars in length (Windows max is 256, changing it requires editing a system variable)

(Unrelated: The code for converting images failed with a JSON KeyError (couldn't find [name] in my data. This was more than I wanted to dig into in the time I had; I ended up having it skip images.)