### PR TITLE
A CLI for trilium-py, maybe

### DIFF
--- a/README-CLI.md
+++ b/README-CLI.md
@@ -4,26 +4,31 @@ An experimental command line interface wrapper for trilium-py, a python library 
 
 I prototyped this as a standalone package first, [trilium-py-cli][tpy]. That seemed promising, so I created this branch in my trilium-py fork to see if it could be merged into the main repository.
 
-uv managed install works, regular pip install doesn't. I don't know why.
+uv managed install works, regular pip install doesn't. I don't know why yet.
 
-I use `uv` from Astral.sh to manage python environments and packages, which uses the newer `pyproject.toml` format, while trilium-py uses the older `setup.py` format. I don't understand setup.py well, and I haven't been able to get the cli script installed using the standard `pip install .` method with setup.py
+I use [`uv`][uv] from Astral to manage python environments and packages, which uses the newer `pyproject.toml` format, while trilium-py uses the older `setup.py` format. I don't understand setup.py well, and I haven't been able to get the cli script installed using the standard `pip install .` The library installs but not the cli script.
 
 
 ## User Installation
 
 ```bash
-uv tool install git+https://github.com/maphew/trilium-py/tree/CLI
+uv tool install https://github.com/maphew/trilium-py/archive/refs/heads/CLI.zip
 ```
 
 This will make the `tpy` command available in your shell. 
 
-(On Windows or systems where git is not in PATH, download the repo archive, unpack it, and run `uv tool install .` from the root directory of the repo.)
+Uninstall:
+
+```bash
+uv tool uninstall trilium-py
+```
 
 ## Developer Installation
 
 ```bash
 git clone https://github.com/maphew/trilium-py.git
 cd trilium-py
+git checkout CLI
 uv sync
 source .venv/bin/activate
 ```
@@ -98,3 +103,4 @@ Fetching server information...
 
 
 [tpy]: https://github.com/maphew/trilium-py-cli
+[uv]: https://astral.sh/uv

--- a/README-CLI.md
+++ b/README-CLI.md
@@ -1,0 +1,100 @@
+# Trilium-py CLI
+
+An experimental command line interface wrapper for trilium-py, a python library for Trilium Notes.
+
+I prototyped this as a standalone package first, [trilium-py-cli][tpy]. That seemed promising, so I created this branch in my trilium-py fork to see if it could be merged into the main repository.
+
+uv managed install works, regular pip install doesn't. I don't know why.
+
+I use `uv` from Astral.sh to manage python environments and packages, which uses the newer `pyproject.toml` format, while trilium-py uses the older `setup.py` format. I don't understand setup.py well, and I haven't been able to get the cli script installed using the standard `pip install .` method with setup.py
+
+
+## User Installation
+
+```bash
+uv tool install git+https://github.com/maphew/trilium-py/tree/CLI
+```
+
+This will make the `tpy` command available in your shell. 
+
+(On Windows or systems where git is not in PATH, download the repo archive, unpack it, and run `uv tool install .` from the root directory of the repo.)
+
+## Developer Installation
+
+```bash
+git clone https://github.com/maphew/trilium-py.git
+cd trilium-py
+uv sync
+source .venv/bin/activate
+```
+
+## Usage
+
+```
+❯ tpy
+Usage: tpy [OPTIONS] COMMAND [ARGS]...
+
+  Trilium-py CLI - Command line interface for trilium-py.
+
+Options:
+  --version        Show the version and exit.
+  --env-file FILE  Path to .env file to load
+  --debug          Enable debug output
+  --help           Show this message and exit.
+
+Commands:
+  config  Manage tpy-cli configuration.
+  info    Display information about the Trilium server.
+  notes   Manage Trilium notes.
+```
+
+Get and save token to .env file:
+
+```
+tpy config get-token
+```
+
+```
+❯ tpy config get-token --server https://www.example.org
+Enter your Trilium password: 
+Connecting to Trilium server at https://www.example.org...
+╭─────────────────── Server Information ───────────────────╮
+│ Trilium: 0.93.0                                          │
+│ Build Date: 2025-04-17T19:25:28Z                         │
+│ Build Revision: 8211fd36af3149c60014737eee2407abb5516974 │
+╰──────────────────────────────────────────────────────────╯
+╭───── Authentication Token ─────╮
+│ Server: https://www.example.org│
+│ Token: Oo919mXP...TdI=         │
+╰────────────────────────────────╯
+
+✓ Token saved to: .env
+
+✓ Successfully connected to Trilium v0.93.0
+```
+
+Show configured server info
+
+```
+❯ tpy info server
+```
+
+```
+Fetching server information...
+╭──────────────────── Trilium Server Information ────────────────────╮
+│ Server                  : https://www.example.org                  │
+│ Token                   : OYE=..............nLNz                   │
+│ App Version             : 0.93.0                                   │
+│ Db Version              : 229                                      │
+│ Node Version            : v22.14.0                                 │
+│ Sync Version            : 34                                       │
+│ Build Date              : 2025-04-17T19:25:28Z                     │
+│ Build Revision          : 8211fd36af3149c60014737eee2407abb5516974 │
+│ Data Directory          : /home/node/trilium-data                  │
+│ Clipper Protocol Version: 1.0                                      │
+│ Utc Date Time           : 2025-04-27T01:06:03.891Z                 │
+╰────────────────────────────────────────────────────────────────────╯
+```
+
+
+[tpy]: https://github.com/maphew/trilium-py-cli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,13 @@
 requires = ["setuptools>=43.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-# Project secton added to support Pixi (by Prefix.dev)
-# https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 [project]
 name = "trilium-py"
 # fetch from setup.py:
 dynamic = ["description", "version","requires-python","authors","keywords","classifiers","dependencies","urls","readme","optional-dependencies"]
+
+[project.scripts]
+tpy = "trilium_py.cli.cli:main"
 
 [tool.black]
 skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,15 +39,16 @@ log_cli_level = "DEBUG"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
-[tool.pixi.project]
-channels = ["conda-forge"]
-platforms = ["win-64"]
+# Now that we have UV we don't need Pixi, since this is a pure python project
+# [tool.pixi.project]
+# channels = ["conda-forge"]
+# platforms = ["win-64"]
 
-[tool.pixi.pypi-dependencies]
-trilium-py = { path = ".", editable = true }
+# [tool.pixi.pypi-dependencies]
+# trilium-py = { path = ".", editable = true }
 
-[tool.pixi.tasks]
+# [tool.pixi.tasks]
 
-[tool.pixi.dependencies]
-python-dateutil = ">=2.9.0,<2.10"
-requests-mock = ">=1.12.1,<1.13"
+# [tool.pixi.dependencies]
+# python-dateutil = ">=2.9.0,<2.10"
+# requests-mock = ">=1.12.1,<1.13"

--- a/setup.py
+++ b/setup.py
@@ -128,8 +128,6 @@ setup(
     # larger catalog.
     keywords='trilium, etapi, api client',  # Optional
     # When your source code is in a subdirectory under the project root, e.g.
-    # `src/`, it is necessary to specify the `package_dir` argument.
-    package_dir={'': 'src'},  # Optional
     # You can just specify package directories manually here if your project is
     # simple. Or you can use find_packages().
     #
@@ -139,7 +137,8 @@ setup(
     #
     #   py_modules=["my_module"],
     #
-    packages=find_packages(where='src'),  # Required
+    packages=find_packages(where='src', include=['trilium_py', 'trilium_py.*']),  # Required
+    package_dir={'': 'src'},  # Required
     # Specify which Python versions you support. In contrast to the
     # 'Programming Language' classifiers above, 'pip install' will check this
     # and refuse to install the project if the version does not match. See
@@ -163,6 +162,10 @@ setup(
         'pillow',
         'python-dateutil',
         'tqdm',
+        # for CLI
+        'click',
+        'python-dotenv',
+        'rich'
     ],
     # Optional
     # List additional groups of dependencies here (e.g. development
@@ -173,10 +176,18 @@ setup(
     #
     # Similar to `install_requires` above, these must be valid existing
     # projects.
-    # extras_require={  # Optional
-    #     'dev': ['check-manifest'],
-    #     'test': ['coverage'],
-    # },
+    extras_require={
+        'dev': [
+            'pytest',
+            'black',
+            'isort',
+            'mypy',
+        ],
+        'test': [
+            'pytest',
+            'pytest-cov',
+        ],
+    },
     # If there are data files included in your packages that need to be
     # installed, specify them here.
     # package_data={  # Optional
@@ -195,11 +206,11 @@ setup(
     #
     # For example, the following would provide a command called `sample` which
     # executes the function `main` from this package when invoked:
-    # entry_points={  # Optional
-    #     'console_scripts': [
-    #         'sample=sample:main',
-    #     ],
-    # },
+    entry_points={
+        'console_scripts': [
+            'tpy=trilium_py.cli.cli:main',
+        ],
+    },
     # List additional URLs that are relevant to your project as a dict.
     #
     # This field corresponds to the "Project-URL" metadata fields:

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ setup(
     # When your source code is in a subdirectory under the project root, e.g.
     # You can just specify package directories manually here if your project is
     # simple. Or you can use find_packages().
+    package_dir={'': 'src'},  # Required
     #
     # Alternatively, if you just want to distribute a single Python file, use
     # the `py_modules` argument instead as follows, which will expect a file
@@ -137,8 +138,8 @@ setup(
     #
     #   py_modules=["my_module"],
     #
-    packages=find_packages(where='src', include=['trilium_py', 'trilium_py.*']),  # Required
-    package_dir={'': 'src'},  # Required
+    # packages=find_packages(where='src', include=['trilium_py', 'trilium_py.*']),  # Required
+    packages=find_packages(where='src'),  # Required
     # Specify which Python versions you support. In contrast to the
     # 'Programming Language' classifiers above, 'pip install' will check this
     # and refuse to install the project if the version does not match. See
@@ -165,7 +166,7 @@ setup(
         # for CLI
         'click',
         'python-dotenv',
-        'rich'
+        'rich',
     ],
     # Optional
     # List additional groups of dependencies here (e.g. development

--- a/src/trilium_py/__init__.py
+++ b/src/trilium_py/__init__.py
@@ -4,6 +4,12 @@
 
 from .version import __version__
 
+# Import the main CLI function
+from .cli.cli import main as cli_main
 
+# For backward compatibility
 def main():
-    pass
+    """CLI entry point."""
+    return cli_main()
+
+__all__ = ['__version__', 'main', 'cli_main']

--- a/src/trilium_py/cli/__init__.py
+++ b/src/trilium_py/cli/__init__.py
@@ -1,0 +1,8 @@
+"""Trilium-py CLI - Command line interface for trilium-py."""
+
+__version__ = "0.1.0"
+
+# Import main CLI function for direct access
+from .cli import main
+
+__all__ = ["__version__", "main"]

--- a/src/trilium_py/cli/cli.py
+++ b/src/trilium_py/cli/cli.py
@@ -1,0 +1,70 @@
+"""Main CLI module for tpy-cli."""
+
+import os
+import click
+from typing import Optional, Any
+from pathlib import Path
+
+from .. import __version__
+from . import utils
+from . import options
+from .utils import load_environment, ensure_config
+from .options import common_options, env_file_option
+
+# Import command groups here to avoid circular imports
+from .commands import info as info_commands
+
+# Commands are registered using the @main.command() decorator
+
+@click.group()
+@click.version_option(version=__version__)
+@env_file_option()  # This is a decorator factory, so we call it
+@click.option(
+    "--debug", is_flag=True, help="Enable debug output"
+)
+@click.pass_context
+def main(ctx: click.Context, env_file: Optional[Path] = None, debug: bool = False, **kwargs: Any) -> None:
+    """Trilium-py CLI - Command line interface for trilium-py.
+    
+    Configuration is loaded in this order:
+      1. Command line arguments
+      2. Environment variables
+      3. Local .env file
+      4. Global ~/.trilium-py/.env file
+    """
+    # Store debug flag in context
+    ctx.ensure_object(dict)
+    ctx.obj["debug"] = debug
+    
+    # Skip configuration check for config commands
+    if ctx.invoked_subcommand == "config":
+        return
+        
+    # Load environment from specified file if provided
+    if env_file:
+        if debug:
+            click.echo(f"[DEBUG] Loading environment from {env_file}", err=True)
+        load_environment(env_file, debug=debug)
+    
+    # Initialize context object with server and token
+    try:
+        # Only try to load config if this is not the info command
+        if ctx.invoked_subcommand != "info":
+            ctx.obj["server"], ctx.obj["token"] = ensure_config(debug=debug)
+    except click.UsageError as e:
+        if debug:
+            click.echo(f"[DEBUG] Configuration error: {e}", err=True)
+        # Allow info commands to run even without config
+        if ctx.invoked_subcommand != "info":
+            raise
+
+# Import and register commands after main is defined to avoid circular imports
+from .commands import notes, config
+
+# Register command groups
+main.add_command(notes.notes, name="notes")
+main.add_command(config.config, name="config")
+main.add_command(info_commands.info, name="info")
+
+if __name__ == "__main__":
+    main()

--- a/src/trilium_py/cli/commands/__init__.py
+++ b/src/trilium_py/cli/commands/__init__.py
@@ -1,0 +1,5 @@
+"""Command modules for tpy-cli."""
+
+from . import notes, config, info
+
+__all__ = ["notes", "config", "info"]

--- a/src/trilium_py/cli/commands/config.py
+++ b/src/trilium_py/cli/commands/config.py
@@ -1,0 +1,265 @@
+"""Configuration commands for tpy-cli."""
+
+import os
+import click
+from pathlib import Path
+import sys
+from typing import Optional, Dict, Any, Tuple
+from pathlib import Path
+
+from ..utils import ENV_FILE, load_environment, get_config
+from ..options import common_options, server_option, token_option
+from trilium_py.client import ETAPI
+
+from rich.console import Console
+from rich.panel import Panel
+
+console = Console()
+
+
+def create_or_update_env(server: Optional[str] = None, token: Optional[str] = None) -> Path:
+    """Create or update .env file with configuration.
+    
+    If .env file doesn't exist, it will be created in the current directory.
+    If it exists, only the specified values will be updated.
+    
+    Args:
+        server: Optional server URL to set
+        token: Optional token to set
+        
+    Returns:
+        Path to the created/updated .env file
+    """
+    # Read existing config if it exists
+    config: Dict[str, str] = {}
+    if ENV_FILE.exists():
+        try:
+            with open(ENV_FILE, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if '=' in line and not line.startswith('#'):
+                        key, value = line.split('=', 1)
+                        config[key.strip()] = value.strip('"\'\n')
+        except Exception as e:
+            click.echo(f"Warning: Could not read existing .env file: {e}", err=True)
+    
+    # Update with new values if provided
+    if server is not None:
+        config["TRILIUM_SERVER"] = server.strip()
+    if token is not None:
+        config["TRILIUM_TOKEN"] = token.strip()
+    
+    # Ensure we have at least server and token
+    if not config.get("TRILIUM_SERVER") or not config.get("TRILIUM_TOKEN"):
+        raise click.UsageError("Both server URL and token are required")
+    
+    # Create parent directories if they don't exist
+    ENV_FILE.parent.mkdir(parents=True, exist_ok=True)
+    
+    # Write to file
+    try:
+        with open(ENV_FILE, 'w') as f:
+            for key, value in config.items():
+                if key and value:  # Skip empty keys or values
+                    f.write(f"{key}={value}\n")
+        
+        # Set permissions to be user-only
+        ENV_FILE.chmod(0o600)
+        return ENV_FILE
+    except Exception as e:
+        raise click.UsageError(f"Failed to write to {ENV_FILE}: {e}")
+
+@click.group()
+def config():
+    """Manage tpy-cli configuration.
+    
+    Configuration is stored in a .env file in the current directory.
+    """
+    pass
+
+
+@config.command()
+@server_option()
+@token_option()
+@click.pass_context
+def set(ctx: click.Context, server: str, token: str) -> None:
+    """Set configuration values in the local .env file."""
+    try:
+        env_file = create_or_update_env(server, token)
+        click.echo(f"Configuration saved to {click.style(str(env_file), fg='green')}")
+    except Exception as e:
+        if ctx.obj.get('debug', False):
+            raise
+        click.echo(f"Error saving configuration: {e}", err=True)
+        raise click.Abort()
+
+
+@config.command()
+@click.option(
+    "--show-token", is_flag=True, 
+    help="Show the full token (by default only shows first and last 4 characters)"
+)
+@click.pass_context
+def show(ctx: click.Context, show_token: bool) -> None:
+    """Show current configuration."""
+    if not ENV_FILE.exists():
+        click.echo("No .env file found in the current directory.")
+        click.echo("\nTo create one, run:")
+        click.echo("  tpy config set --server URL --token TOKEN")
+        return
+    
+    click.echo(f"Configuration file: {click.style(str(ENV_FILE), fg='cyan')}")
+    click.echo("-" * 60)
+    
+    try:
+        with open(ENV_FILE, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    click.echo(click.style(line, fg='bright_black'))
+                    continue
+                    
+                if '=' not in line:
+                    continue
+                    
+                key, value = line.split('=', 1)
+                key = key.strip()
+                value = value.strip().strip('\"\'')
+                
+                if key.startswith('TRILIUM_'):
+                    if key == 'TRILIUM_TOKEN' and not show_token and len(value) > 8:
+                        value = f"{value[:4]}...{value[-4:]}"
+                    click.echo(f"{click.style(key, fg='green')}={click.style(value, fg='yellow')}")
+    except Exception as e:
+        if ctx.obj.get('debug', False):
+            raise
+        click.echo(f"Error reading configuration: {e}", err=True)
+        raise click.Abort()
+    
+    if not show_token and ENV_FILE.exists() and any('TRILIUM_TOKEN' in line for line in open(ENV_FILE)):
+        click.echo("\n" + click.style("Note: ", fg='yellow') + 
+                  "Token is partially hidden. Use --show-token to display the full token.")
+
+
+@config.command()
+@click.confirmation_option(prompt="Are you sure you want to delete the .env file?")
+@click.pass_context
+def delete(ctx: click.Context) -> None:
+    """Delete the local .env file."""
+    if not ENV_FILE.exists():
+        click.echo("No .env file found in the current directory.")
+        return
+    
+    try:
+        ENV_FILE.unlink()
+        click.echo(f"Deleted configuration file: {click.style(str(ENV_FILE), fg='red')}")
+    except Exception as e:
+        if ctx.obj.get('debug', False):
+            raise
+        click.echo(f"Error deleting configuration: {e}", err=True)
+        raise click.Abort()
+
+
+def get_token_from_server(server_url: str, password: str) -> Tuple[str, dict]:
+    """
+    Connect to Trilium server and get an ETAPI token using password.
+    
+    Args:
+        server_url: URL of the Trilium server
+        password: Password for the Trilium instance
+        
+    Returns:
+        tuple: (token, app_info)
+    """
+    try:
+        ea = ETAPI(server_url)
+        token = ea.login(password)
+        
+        if not token:
+            raise click.ClickException("Failed to authenticate with the provided password")
+        
+        app_info = ea.app_info()
+        return token, app_info
+    except Exception as e:
+        raise click.ClickException(f"Failed to get token from server: {e}")
+
+
+@config.command()
+@click.argument("password", required=False)
+@click.option(
+    "--server",
+    "server_url",
+    help="Trilium server URL (e.g., http://localhost:8080)",
+    required=True,
+)
+@click.option(
+    "--save/--no-save",
+    default=True,
+    help="Save the token to the configuration file",
+    show_default=True,
+)
+@click.pass_context
+def get_token(
+    ctx: click.Context, 
+    password: Optional[str], 
+    server_url: str, 
+    save: bool
+) -> None:
+    """Get a new ETAPI token from Trilium server.
+    
+    This command will authenticate with the Trilium server using the provided
+    password and retrieve a new ETAPI token. The token can be saved to the
+    configuration file for future use.
+    
+    Example:
+        tpy config get-token yourpassword --server http://localhost:8080
+    """
+    try:
+        # Prompt for password if not provided
+        if not password:
+            password = click.prompt("Enter your Trilium password", hide_input=True)
+            
+        # Get token from server
+        console.print(f"Connecting to Trilium server at [bold]{server_url}[/bold]...")
+        token, app_info = get_token_from_server(server_url, password)
+        
+        # Display app info
+        console.print(Panel.fit(
+            f"[bold]Trilium:[/bold] {app_info.get('appVersion', 'Unknown')}\n"
+            f"[bold]Build Date:[/bold] {app_info.get('buildDate', 'Unknown')}\n"
+            f"[bold]Build Revision:[/bold] {app_info.get('buildRevision', 'Unknown')}",
+            title="Server Information"
+        ))
+        
+        # Display token info
+        console.print(Panel.fit(
+            f"[bold]Server:[/bold] {server_url}\n"
+            f"[bold]Token:[/bold] {token[:8]}...{token[-4:] if len(token) > 12 else ''}",
+            title="Authentication Token",
+            border_style="green"
+        ))
+        
+        # Save token if requested
+        if save:
+            try:
+                env_path = create_or_update_env(server=server_url, token=token)
+                console.print(f"\n[green]✓ Token saved to: {env_path}[/green]")
+                
+                # Test the token
+                try:
+                    ea = ETAPI(server_url, token)
+                    user_info = ea.app_info()
+                    console.print(f"\n[green]✓ Successfully connected to {user_info.get('appName', 'Trilium')} v{user_info.get('appVersion', '')}[/green]")
+                except Exception as e:
+                    console.print(f"[yellow]Warning: Could not verify token: {e}[/yellow]")
+                    
+            except Exception as e:
+                console.print(f"[red]Error saving token: {e}[/red]")
+                if ctx.obj.get('debug', False):
+                    raise
+                return 1
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        if ctx.obj.get('debug', False):
+            raise
+        return 1

--- a/src/trilium_py/cli/commands/info.py
+++ b/src/trilium_py/cli/commands/info.py
@@ -1,0 +1,76 @@
+"""Commands for displaying Trilium server information."""
+
+import click
+from typing import Optional, Any
+from pathlib import Path
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from trilium_py.client import ETAPI
+
+# Import utils here to avoid circular imports
+from .. import utils
+
+console = Console()
+
+@click.group()
+def info() -> None:
+    """Display information about the Trilium server."""
+    pass
+
+@info.command()
+@click.pass_context
+def server(ctx: click.Context) -> None:
+    """Display information about the connected Trilium server."""
+    try:
+        # Get ETAPI client using the utility function
+        ea = utils.get_etapi(ctx)
+        
+        # Get and display app info
+        console.print("Fetching server information...")
+        app_info = ea.app_info()
+        
+        # Display connection info
+        server_url = ea.server_url
+        token = ea.token
+
+        # keys are in camelCase, convert to Space Separated Words and format each line
+        def format_key(key: str) -> str:
+            # Split words on capitals, then capitalize first letter of each word
+            import re
+            words = re.sub('([A-Z][a-z]+)', r' \1', re.sub('([A-Z]+)', r' \1', key)).split()
+            return ' '.join(word.capitalize() for word in words)
+            
+        # Build formatted lines with consistent alignment
+        formatted_lines = []
+        
+        # Connection info
+        formatted_lines.append(f"[bold]Server[/]{''.ljust(18)}: {server_url}")
+        formatted_lines.append(f"[bold]Token [/]{''.ljust(18)}: {token[-4:]}{'.'*(len(server_url)-8)}{token[:4]}")
+        
+        # App info
+        for key, value in app_info.items():
+            # Format the key with color and alignment
+            formatted_key = f"[cyan]{format_key(key).ljust(24)}[/]"
+            # Convert value to string and handle None
+            formatted_value = str(value) if value is not None else "-"
+            formatted_lines.append(f"{formatted_key}: {formatted_value}")
+        
+        # Display in a panel with consistent formatting
+        console.print(Panel.fit(
+            "\n".join(formatted_lines),
+            title="[bold blue]Trilium Server Information[/]",
+            border_style="blue"
+        ))
+        
+    except Exception as e:
+        console.print(Panel.fit(
+            f"[bold red]✗ Failed to connect: {str(e)}[/bold red]\n\n"
+            "Please check your configuration and ensure:\n"
+            "- Server URL is correct\n"
+            "- Token is valid\n"
+            "- Trilium server is running and accessible",
+            title="Connection Failed",
+            border_style="red"
+        ))
+        raise click.Abort()

--- a/src/trilium_py/cli/commands/notes.py
+++ b/src/trilium_py/cli/commands/notes.py
@@ -1,0 +1,291 @@
+"""Note-related commands for tpy-cli."""
+
+import click
+from pathlib import Path
+from typing import Optional, Any
+from trilium_py.client import ETAPI
+
+from ..options import common_options
+from ..utils import ensure_config
+
+@click.group()
+def notes() -> None:
+    """Manage Trilium notes."""
+    pass
+
+def get_etapi(ctx: click.Context) -> ETAPI:
+    """Get ETAPI client from context or environment.
+    
+    Args:
+        ctx: Click context object
+        
+    Returns:
+        ETAPI: Initialized ETAPI client
+        
+    Raises:
+        click.UsageError: If configuration is missing
+    """
+    debug = ctx.obj.get("debug", False)
+    server = ctx.obj.get("server")
+    token = ctx.obj.get("token")
+    
+    if debug:
+        click.echo(f"[DEBUG] Creating ETAPI client with server: {server[:10]}...", err=True)
+    
+    try:
+        return ETAPI(server, token)
+    except Exception as e:
+        if debug:
+            click.echo(f"[DEBUG] Failed to create ETAPI client: {e}", err=True)
+        raise click.UsageError(
+            "Failed to connect to Trilium. Please check your server URL and token."
+        )
+
+@notes.command()
+@click.argument("query")
+@click.pass_context
+def search(ctx: click.Context, query: str) -> None:
+    """Search for notes matching QUERY.
+    
+    Examples:
+        tpy notes search "my search term"
+    """
+    try:
+        ea = get_etapi(ctx)
+        click.echo(f"Searching for: {click.style(query, fg='cyan')}")
+        
+        # Get search results using the direct query
+        results = ea.search_note(query)
+        
+        # Extract notes from the response
+        if isinstance(results, dict) and 'results' in results:
+            notes = results['results']
+        elif isinstance(results, list):
+            notes = results
+        else:
+            click.echo("Error: Unexpected response format from server")
+            if click.confirm('Show raw response?', default=False):
+                click.echo(f"Raw response: {results}")
+            return
+            
+        if not notes:
+            click.echo("No matching notes found.")
+            return
+            
+        click.echo(f"\nFound {click.style(str(len(notes)), fg='green')} notes:")
+        
+        for i, note in enumerate(notes, 1):
+            if not isinstance(note, dict):
+                click.echo(f"  {i}. [red]Invalid note format: {note}[/]")
+                continue
+                
+            # Get note details with safe defaults
+            note_id = note.get('noteId', 'N/A')
+            title = note.get('title', 'Untitled')
+            
+            # Display note
+            click.echo(f"  {i}. {click.style(title, fg='yellow')} ({note_id})")
+            
+            # Show content preview if available
+            content = note.get('content')
+            if content and isinstance(content, str):
+                preview = content[:100].replace('\n', ' ')
+                if len(content) > 100:
+                    preview += "..."
+                click.echo(f"     {preview}")
+                
+            click.echo()  # Add spacing between notes
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        raise click.Abort()
+
+@notes.command()
+@click.argument("title")
+@click.option(
+    "--parent-id", 
+    "parent_id", 
+    required=True, 
+    help="Parent note ID (use 'root' for root level)",
+    default="root"
+)
+@click.option(
+    "--type", 
+    "note_type", 
+    default="text", 
+    help="Note type (text, code, book, etc.)",
+    show_default=True
+)
+@click.option(
+    "--mime", 
+    default="text/html", 
+    help="MIME type (e.g., text/html, text/x-markdown, text/plain)",
+    show_default=True
+)
+@click.option(
+    "--content", 
+    default="", 
+    help="Note content. Use @filename to read from a file."
+)
+@click.option(
+    "--dry-run", 
+    is_flag=True,
+    help="Show what would be created without actually creating"
+)
+@click.pass_context
+def create(
+    ctx: click.Context,
+    title: str,
+    parent_id: str,
+    note_type: str,
+    mime: str,
+    content: str,
+    dry_run: bool,
+) -> None:
+    """Create a new note in Trilium.
+    
+    Examples:
+        # Create a simple note
+        tpy notes create "My Note" --parent-id root --content "Hello, World!"
+        
+        # Create a note from file content
+        tpy notes create "From File" --parent-id root --content @note.md
+        
+        # Create a code note
+        tpy notes create "My Script" --type code --mime text/x-python --parent-id root --content @script.py
+    """
+    
+    print("forcing dry run. Create is not safe yet.")
+    dry_run = True
+
+    try:
+        # Handle file content if content starts with @
+        if content.startswith('@'):
+            file_path = Path(content[1:]).expanduser()
+            if not file_path.exists():
+                raise click.BadParameter(f"File not found: {file_path}")
+            with open(file_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+                if not mime and file_path.suffix == '.md':
+                    mime = 'text/x-markdown'
+                elif not mime and file_path.suffix == '.py':
+                    mime = 'text/x-python'
+        
+        # Show preview in dry-run mode
+        if dry_run:
+            click.echo(click.style("=== DRY RUN ===", fg='yellow', bold=True))
+            click.echo(f"Title:       {click.style(title, fg='cyan')}")
+            click.echo(f"Parent ID:   {click.style(parent_id, fg='cyan')}")
+            click.echo(f"Type:        {click.style(note_type, fg='cyan')}")
+            click.echo(f"MIME:        {click.style(mime, fg='cyan')}")
+            click.echo(f"Content size: {click.style(str(len(content)), fg='cyan')} chars")
+            if content:
+                preview = content[:200].replace('\n', '\\n')
+                if len(content) > 200:
+                    preview += "..."
+                click.echo(f"Preview:     {preview}")
+            return
+        
+        # Create the note
+        ea = get_etapi(ctx)
+        note = ea.create_note(
+            title=title,
+            parentNoteId=parent_id,
+            type=note_type,
+            mime=mime,
+            content=content,
+        )
+        
+        click.echo(click.style("✓ ", fg='green', bold=True) + 
+                 f"Created note: {click.style(note['noteId'], fg='cyan')}")
+        click.echo(f"Title: {click.style(note.get('title', 'Untitled'), fg='yellow')}")
+        
+    except Exception as e:
+        if ctx.obj.get('debug', False):
+            raise
+        click.echo(click.style("Error creating note: ", fg='red') + str(e), err=True)
+        raise click.Abort()
+
+@notes.command()
+@click.option(
+    "--root", 
+    default="root", 
+    help="Root note ID to start the tree from (default: root)",
+    show_default=True
+)
+@click.option(
+    "--max-depth", 
+    type=int, 
+    default=3,
+    help="Maximum depth to display in the tree",
+    show_default=True
+)
+@click.option(
+    "--show-ids",
+    is_flag=True,
+    help="Show note IDs in the tree"
+)
+@click.pass_context
+def tree(ctx: click.Context, root: str, max_depth: int, show_ids: bool) -> None:
+    """Display notes in a tree structure.
+    
+    Examples:
+        # Show full tree starting from root
+        tpy notes tree
+        
+        # Show tree starting from a specific note
+        tpy notes tree --root abc123xyz
+        
+        # Show deeper tree with note IDs
+        tpy notes tree --max-depth 5 --show-ids
+    """
+    try:
+        ea = get_etapi(ctx)
+        
+        def print_note(note_id: str, prefix: str = "", depth: int = 0) -> None:
+            if depth > max_depth:
+                return
+                
+            try:
+                note = ea.get_note(note_id)
+                title = note.get('title', 'Untitled')
+                
+                # Build the line with appropriate prefix and styling
+                line_parts = []
+                if prefix:
+                    line_parts.append(click.style(prefix, fg='bright_black'))
+                
+                line_parts.append(click.style(title, fg='cyan' if depth == 0 else 'white'))
+                
+                if show_ids:
+                    line_parts.append(click.style(f"({note_id})", fg='bright_black'))
+                
+                click.echo("".join(line_parts))
+                
+                # Get and display child notes
+                children = ea.get_child_notes(note_id)
+                for i, child in enumerate(children):
+                    is_last = i == len(children) - 1
+                    child_prefix = "    " + ("    " * depth)
+                    
+                    if is_last:
+                        child_prefix += "└── "
+                    else:
+                        child_prefix += "├── "
+                    
+                    print_note(child['noteId'], child_prefix, depth + 1)
+                    
+            except Exception as e:
+                if ctx.obj.get('debug', False):
+                    click.echo(f"Error processing note {note_id}: {e}", err=True)
+        
+        click.echo(click.style(f"Note Tree (max depth: {max_depth}):", bold=True))
+        print_note(root)
+        
+    except Exception as e:
+        if ctx.obj.get('debug', False):
+            raise
+        click.echo(click.style("Error: ", fg='red') + str(e), err=True)
+        raise click.Abort()
+
+
+# Add more note commands here as needed

--- a/src/trilium_py/cli/options.py
+++ b/src/trilium_py/cli/options.py
@@ -1,0 +1,39 @@
+"""Common CLI options for tpy-cli."""
+
+import click
+from typing import Callable, Any, TypeVar, Optional
+from pathlib import Path
+
+F = TypeVar('F', bound=Callable[..., Any])
+
+def server_option() -> Callable[[F], F]:
+    """Decorator to add --server option to a command."""
+    return click.option(
+        "--server",
+        envvar="TRILIUM_SERVER",
+        help="Trilium server URL (e.g., http://localhost:8080)",
+        required=False,
+    )
+
+def token_option() -> Callable[[F], F]:
+    """Decorator to add --token option to a command."""
+    return click.option(
+        "--token",
+        envvar="TRILIUM_TOKEN",
+        help="Trilium ETAPI token",
+        required=False,
+    )
+
+def common_options(func: F) -> F:
+    """Decorator to add common options to a command."""
+    func = server_option()(func)
+    func = token_option()(func)
+    return func
+
+def env_file_option() -> Callable[[F], F]:
+    """Decorator to add --env-file option to a command."""
+    return click.option(
+        "--env-file",
+        type=click.Path(exists=True, dir_okay=False, path_type=Path),
+        help="Path to .env file to load",
+    )

--- a/src/trilium_py/cli/utils.py
+++ b/src/trilium_py/cli/utils.py
@@ -1,0 +1,195 @@
+"""Utility functions for tpy-cli."""
+
+import os
+import click
+from pathlib import Path
+from typing import Optional, Tuple, Any, Dict
+
+from dotenv import load_dotenv
+from trilium_py.client import ETAPI
+
+# Configuration file paths
+ENV_FILE = Path(".env")  # Local .env file
+
+
+def load_environment(env_file: Optional[Path] = None, debug: bool = False) -> bool:
+    """Load environment variables from .env file or environment.
+    
+    Order of precedence:
+    1. Environment variables
+    2. Specified .env file (if provided and exists)
+    3. Local .env file (if exists)
+    
+    Args:
+        env_file: Optional path to a custom .env file
+        debug: If True, print debug information
+        
+    Returns:
+        bool: True if the environment was loaded successfully
+    """
+    def debug_print(msg: str) -> None:
+        if debug:
+            click.echo(f"[DEBUG] {msg}", err=True)
+    
+    # Try to load from specified env file if provided
+    if env_file is not None:
+        if env_file.exists():
+            debug_print(f"Loading environment from {env_file}")
+            return load_dotenv(env_file, override=True)
+        debug_print(f"Specified .env file not found: {env_file}")
+        return False
+    
+    # Try local .env file
+    if ENV_FILE.exists():
+        debug_print(f"Loading environment from {ENV_FILE}")
+        return load_dotenv(ENV_FILE, override=True)
+    
+    debug_print("No .env file found")
+    return False
+
+
+def get_etapi(ctx: click.Context) -> ETAPI:
+    """Get an ETAPI client from the Click context.
+    
+    Args:
+        ctx: Click context object containing server and token
+        
+    Returns:
+        ETAPI: Configured ETAPI client
+        
+    Raises:
+        click.UsageError: If server or token is missing
+    """
+    server = ctx.obj.get("server")
+    token = ctx.obj.get("token")
+    debug = ctx.obj.get("debug", False)
+    
+    if not server or not token:
+        # Try to get from environment
+        server, token = ensure_config(debug=debug)
+        if not server or not token:
+            raise click.UsageError(
+                "Missing server or token. Please configure with:\n"
+                "  tpy config set --server URL --token TOKEN"
+            )
+    
+    if debug:
+        click.echo(f"[DEBUG] Creating ETAPI client for {server}", err=True)
+    
+    try:
+        return ETAPI(server, token)
+    except Exception as e:
+        if debug:
+            click.echo(f"[DEBUG] Failed to create ETAPI client: {e}", err=True)
+        raise click.UsageError(
+            "Failed to connect to Trilium. Please check your server URL and token."
+        )
+
+
+def get_config(debug: bool = False) -> Tuple[Optional[str], Optional[str]]:
+    """Get server URL and token from environment or .env file.
+    
+    Args:
+        debug: If True, print debug information
+        
+    Returns:
+        tuple: (server_url, token) - either or both may be None if not found
+    """
+    # Try to load from environment variables first
+    server_url = os.getenv("TRILIUM_SERVER")
+    token = os.getenv("TRILIUM_TOKEN")
+    
+    # If not found, try loading from .env file
+    if not (server_url and token):
+        load_environment(debug=debug)
+        server_url = os.getenv("TRILIUM_SERVER")
+        token = os.getenv("TRILIUM_TOKEN")
+    
+    return server_url, token
+
+
+def ensure_config(server: Optional[str] = None, token: Optional[str] = None, 
+                 debug: bool = False) -> Tuple[str, str]:
+    """Ensure we have server URL and token, either from args or environment.
+    
+    Args:
+        server: Optional server URL from command line
+        token: Optional token from command line
+        debug: If True, print debug information
+        
+    Returns:
+        tuple: (server_url, token)
+        
+    Raises:
+        click.UsageError: If configuration is missing or invalid
+    """
+    def debug_print(msg: str) -> None:
+        if debug:
+            click.echo(f"[DEBUG] {msg}", err=True)
+    
+    # Check command line arguments first
+    if server:
+        debug_print(f"Using server from command line: {server[:10]}...")
+    if token:
+        debug_print("Using token from command line: [REDACTED]")
+    
+    # Then check environment variables
+    if not server or not token:
+        env_server, env_token = get_config(debug=debug)
+        server = server or env_server
+        token = token or env_token
+        
+        if env_server and not server:
+            debug_print("Using server from environment")
+        if env_token and not token:
+            debug_print("Using token from environment")
+    
+    # Final validation
+    if not server or not token:
+        debug_print("Configuration not found in any source")
+        
+        # Build helpful error message
+        msg = [
+            "Missing configuration. Please use one of these methods:",
+            "  1. Command line: tpy --server URL --token TOKEN [command]",
+            "  2. Environment variables: TRILIUM_SERVER and TRILIUM_TOKEN",
+            "  3. .env file in the current directory"
+        ]
+        
+        # Check if we're in the right directory
+        cwd = Path.cwd()
+        if str(cwd) != str(Path.home()):
+            msg.append(f"\nCurrent directory: {cwd}")
+        
+        # Check for common issues
+        issues = []
+        if server and not token:
+            issues.append("Server URL is set but token is missing")
+        elif token and not server:
+            issues.append("Token is set but server URL is missing")
+            
+        if issues:
+            msg.append("\nIssues found:")
+            for issue in issues:
+                msg.append(f"  • {issue}")
+        
+        # Add example
+        msg.extend([
+            "",
+            "Example .env file:",
+            "  TRILIUM_SERVER=https://your-trillium-instance.com",
+            "  TRILIUM_TOKEN=your-api-token-here",
+            "",
+            "To configure, run:",
+            "  tpy config set --server URL --token TOKEN"
+        ])
+        
+        raise click.UsageError("\n".join(msg))
+    
+    # Basic URL validation
+    if not server.startswith(('http://', 'https://')):
+        debug_print("Server URL should start with http:// or https://")
+        raise click.UsageError("Server URL must start with http:// or https://")
+    
+    debug_print("Configuration loaded successfully")
+    return server, token

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,568 @@
+version = 1
+revision = 2
+requires-python = ">=3.13"
+resolution-markers = [
+    "sys_platform == 'darwin'",
+    "sys_platform == 'linux'",
+    "sys_platform != 'darwin' and sys_platform != 'linux'",
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067, upload-time = "2025-04-15T17:05:13.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/cd/30110dc0ffcf3b131156077b90e9f60ed75711223f306da4db08eff8403b/beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b", size = 187285, upload-time = "2025-04-15T17:05:12.221Z" },
+]
+
+[[package]]
+name = "black"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/49/26a7b0f3f35da4b5a65f081943b7bcd22d7002f5f0fb8098ec1ff21cb6ef/black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666", size = 649449, upload-time = "2025-01-29T04:15:40.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/87/0edf98916640efa5d0696e1abb0a8357b52e69e82322628f25bf14d263d1/black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f", size = 1650673, upload-time = "2025-01-29T05:37:20.574Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e5/f7bf17207cf87fa6e9b676576749c6b6ed0d70f179a3d812c997870291c3/black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3", size = 1453190, upload-time = "2025-01-29T05:37:22.106Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926, upload-time = "2025-01-29T04:18:58.564Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613, upload-time = "2025-01-29T04:19:27.63Z" },
+    { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646, upload-time = "2025-01-29T04:15:38.082Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.4.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705, upload-time = "2025-04-26T02:12:29.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618, upload-time = "2025-04-26T02:12:27.662Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367, upload-time = "2025-05-02T08:34:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/12/a93df3366ed32db1d907d7593a94f1fe6293903e3e92967bebd6950ed12c/charset_normalizer-3.4.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0", size = 199622, upload-time = "2025-05-02T08:32:56.363Z" },
+    { url = "https://files.pythonhosted.org/packages/04/93/bf204e6f344c39d9937d3c13c8cd5bbfc266472e51fc8c07cb7f64fcd2de/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf", size = 143435, upload-time = "2025-05-02T08:32:58.551Z" },
+    { url = "https://files.pythonhosted.org/packages/22/2a/ea8a2095b0bafa6c5b5a55ffdc2f924455233ee7b91c69b7edfcc9e02284/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e", size = 153653, upload-time = "2025-05-02T08:33:00.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/57/1b090ff183d13cef485dfbe272e2fe57622a76694061353c59da52c9a659/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1", size = 146231, upload-time = "2025-05-02T08:33:02.081Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c", size = 148243, upload-time = "2025-05-02T08:33:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/0f/9abe9bd191629c33e69e47c6ef45ef99773320e9ad8e9cb08b8ab4a8d4cb/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691", size = 150442, upload-time = "2025-05-02T08:33:06.418Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/a123bbcedca91d5916c056407f89a7f5e8fdfce12ba825d7d6b9954a1a3c/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0", size = 145147, upload-time = "2025-05-02T08:33:08.183Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/fe/1ac556fa4899d967b83e9893788e86b6af4d83e4726511eaaad035e36595/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b", size = 153057, upload-time = "2025-05-02T08:33:09.986Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/ff/acfc0b0a70b19e3e54febdd5301a98b72fa07635e56f24f60502e954c461/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff", size = 156454, upload-time = "2025-05-02T08:33:11.814Z" },
+    { url = "https://files.pythonhosted.org/packages/92/08/95b458ce9c740d0645feb0e96cea1f5ec946ea9c580a94adfe0b617f3573/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b", size = 154174, upload-time = "2025-05-02T08:33:13.707Z" },
+    { url = "https://files.pythonhosted.org/packages/78/be/8392efc43487ac051eee6c36d5fbd63032d78f7728cb37aebcc98191f1ff/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148", size = 149166, upload-time = "2025-05-02T08:33:15.458Z" },
+    { url = "https://files.pythonhosted.org/packages/44/96/392abd49b094d30b91d9fbda6a69519e95802250b777841cf3bda8fe136c/charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7", size = 98064, upload-time = "2025-05-02T08:33:17.06Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b0/0200da600134e001d91851ddc797809e2fe0ea72de90e09bec5a2fbdaccb/charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980", size = 105641, upload-time = "2025-05-02T08:33:18.753Z" },
+    { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626, upload-time = "2025-05-02T08:34:40.053Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/07/998afa4a0ecdf9b1981ae05415dad2d4e7716e1b1f00abbd91691ac09ac9/coverage-7.8.2.tar.gz", hash = "sha256:a886d531373a1f6ff9fad2a2ba4a045b68467b779ae729ee0b3b10ac20033b27", size = 812759, upload-time = "2025-05-23T11:39:57.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/93/eb6400a745ad3b265bac36e8077fdffcf0268bdbbb6c02b7220b624c9b31/coverage-7.8.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ea561010914ec1c26ab4188aef8b1567272ef6de096312716f90e5baa79ef8ca", size = 211898, upload-time = "2025-05-23T11:38:49.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/7c/bdbf113f92683024406a1cd226a199e4200a2001fc85d6a6e7e299e60253/coverage-7.8.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cb86337a4fcdd0e598ff2caeb513ac604d2f3da6d53df2c8e368e07ee38e277d", size = 212171, upload-time = "2025-05-23T11:38:51.207Z" },
+    { url = "https://files.pythonhosted.org/packages/91/22/594513f9541a6b88eb0dba4d5da7d71596dadef6b17a12dc2c0e859818a9/coverage-7.8.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a4636ddb666971345541b59899e969f3b301143dd86b0ddbb570bd591f1e85", size = 245564, upload-time = "2025-05-23T11:38:52.857Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f4/2860fd6abeebd9f2efcfe0fd376226938f22afc80c1943f363cd3c28421f/coverage-7.8.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5040536cf9b13fb033f76bcb5e1e5cb3b57c4807fef37db9e0ed129c6a094257", size = 242719, upload-time = "2025-05-23T11:38:54.529Z" },
+    { url = "https://files.pythonhosted.org/packages/89/60/f5f50f61b6332451520e6cdc2401700c48310c64bc2dd34027a47d6ab4ca/coverage-7.8.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc67994df9bcd7e0150a47ef41278b9e0a0ea187caba72414b71dc590b99a108", size = 244634, upload-time = "2025-05-23T11:38:57.326Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/70/7f4e919039ab7d944276c446b603eea84da29ebcf20984fb1fdf6e602028/coverage-7.8.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e6c86888fd076d9e0fe848af0a2142bf606044dc5ceee0aa9eddb56e26895a0", size = 244824, upload-time = "2025-05-23T11:38:59.421Z" },
+    { url = "https://files.pythonhosted.org/packages/26/45/36297a4c0cea4de2b2c442fe32f60c3991056c59cdc3cdd5346fbb995c97/coverage-7.8.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:684ca9f58119b8e26bef860db33524ae0365601492e86ba0b71d513f525e7050", size = 242872, upload-time = "2025-05-23T11:39:01.049Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/71/e041f1b9420f7b786b1367fa2a375703889ef376e0d48de9f5723fb35f11/coverage-7.8.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8165584ddedb49204c4e18da083913bdf6a982bfb558632a79bdaadcdafd0d48", size = 244179, upload-time = "2025-05-23T11:39:02.709Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/db/3c2bf49bdc9de76acf2491fc03130c4ffc51469ce2f6889d2640eb563d77/coverage-7.8.2-cp313-cp313-win32.whl", hash = "sha256:34759ee2c65362163699cc917bdb2a54114dd06d19bab860725f94ef45a3d9b7", size = 214393, upload-time = "2025-05-23T11:39:05.457Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/dc/947e75d47ebbb4b02d8babb1fad4ad381410d5bc9da7cfca80b7565ef401/coverage-7.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:2f9bc608fbafaee40eb60a9a53dbfb90f53cc66d3d32c2849dc27cf5638a21e3", size = 215194, upload-time = "2025-05-23T11:39:07.171Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/a980f7df8a37eaf0dc60f932507fda9656b3a03f0abf188474a0ea188d6d/coverage-7.8.2-cp313-cp313-win_arm64.whl", hash = "sha256:9fe449ee461a3b0c7105690419d0b0aba1232f4ff6d120a9e241e58a556733f7", size = 213580, upload-time = "2025-05-23T11:39:08.862Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6a/25a37dd90f6c95f59355629417ebcb74e1c34e38bb1eddf6ca9b38b0fc53/coverage-7.8.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8369a7c8ef66bded2b6484053749ff220dbf83cba84f3398c84c51a6f748a008", size = 212734, upload-time = "2025-05-23T11:39:11.109Z" },
+    { url = "https://files.pythonhosted.org/packages/36/8b/3a728b3118988725f40950931abb09cd7f43b3c740f4640a59f1db60e372/coverage-7.8.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:159b81df53a5fcbc7d45dae3adad554fdbde9829a994e15227b3f9d816d00b36", size = 212959, upload-time = "2025-05-23T11:39:12.751Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3c/212d94e6add3a3c3f412d664aee452045ca17a066def8b9421673e9482c4/coverage-7.8.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6fcbbd35a96192d042c691c9e0c49ef54bd7ed865846a3c9d624c30bb67ce46", size = 257024, upload-time = "2025-05-23T11:39:15.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/40/afc03f0883b1e51bbe804707aae62e29c4e8c8bbc365c75e3e4ddeee9ead/coverage-7.8.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05364b9cc82f138cc86128dc4e2e1251c2981a2218bfcd556fe6b0fbaa3501be", size = 252867, upload-time = "2025-05-23T11:39:17.64Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a2/3699190e927b9439c6ded4998941a3c1d6fa99e14cb28d8536729537e307/coverage-7.8.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46d532db4e5ff3979ce47d18e2fe8ecad283eeb7367726da0e5ef88e4fe64740", size = 255096, upload-time = "2025-05-23T11:39:19.328Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/06/16e3598b9466456b718eb3e789457d1a5b8bfb22e23b6e8bbc307df5daf0/coverage-7.8.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4000a31c34932e7e4fa0381a3d6deb43dc0c8f458e3e7ea6502e6238e10be625", size = 256276, upload-time = "2025-05-23T11:39:21.077Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d5/4b5a120d5d0223050a53d2783c049c311eea1709fa9de12d1c358e18b707/coverage-7.8.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:43ff5033d657cd51f83015c3b7a443287250dc14e69910577c3e03bd2e06f27b", size = 254478, upload-time = "2025-05-23T11:39:22.838Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/85/f9ecdb910ecdb282b121bfcaa32fa8ee8cbd7699f83330ee13ff9bbf1a85/coverage-7.8.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94316e13f0981cbbba132c1f9f365cac1d26716aaac130866ca812006f662199", size = 255255, upload-time = "2025-05-23T11:39:24.644Z" },
+    { url = "https://files.pythonhosted.org/packages/50/63/2d624ac7d7ccd4ebbd3c6a9eba9d7fc4491a1226071360d59dd84928ccb2/coverage-7.8.2-cp313-cp313t-win32.whl", hash = "sha256:3f5673888d3676d0a745c3d0e16da338c5eea300cb1f4ada9c872981265e76d8", size = 215109, upload-time = "2025-05-23T11:39:26.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5e/7053b71462e970e869111c1853afd642212568a350eba796deefdfbd0770/coverage-7.8.2-cp313-cp313t-win_amd64.whl", hash = "sha256:2c08b05ee8d7861e45dc5a2cc4195c8c66dca5ac613144eb6ebeaff2d502e73d", size = 216268, upload-time = "2025-05-23T11:39:28.429Z" },
+    { url = "https://files.pythonhosted.org/packages/07/69/afa41aa34147655543dbe96994f8a246daf94b361ccf5edfd5df62ce066a/coverage-7.8.2-cp313-cp313t-win_arm64.whl", hash = "sha256:1e1448bb72b387755e1ff3ef1268a06617afd94188164960dba8d0245a46004b", size = 214071, upload-time = "2025-05-23T11:39:30.55Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1a/0b9c32220ad694d66062f571cc5cedfa9997b64a591e8a500bb63de1bd40/coverage-7.8.2-py3-none-any.whl", hash = "sha256:726f32ee3713f7359696331a18daf0c3b3a70bb0ae71141b9d3c52be7c595e32", size = 203623, upload-time = "2025-05-23T11:39:53.846Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "isort"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/21/1e2a441f74a653a144224d7d21afe8f4169e6c7c20bb13aec3a2dc3815e0/isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450", size = 821955, upload-time = "2025-02-26T21:13:16.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/11/114d0a5f4dabbdcedc1125dee0888514c3c3b16d3e9facad87ed96fad97c/isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615", size = 94186, upload-time = "2025-02-26T21:13:14.911Z" },
+]
+
+[[package]]
+name = "latex2mathml"
+version = "3.78.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/33/ad2c3929494ad160f5130ea132ca298627a6c81c70be6bedd1bc806b5b01/latex2mathml-3.78.0.tar.gz", hash = "sha256:712193aa4c6ade1a8e0145dac7bc1f9aafbd54f93046a2356a7e1c05fa0f8b31", size = 73737, upload-time = "2025-05-03T16:51:53.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/fd/aba08bb9e527168efad57985d7db9a853eb2384b1efa5ca5f3a3794c9cef/latex2mathml-3.78.0-py3-none-any.whl", hash = "sha256:1aeca3dc027b3006ad7b301b7f4a15ffbb4c1451e3dc8c3389e97b37b497e1d6", size = 73673, upload-time = "2025-05-03T16:51:51.991Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markdown2"
+version = "2.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/52/d7dcc6284d59edb8301b8400435fbb4926a9b0f13a12b5cbaf3a4a54bb7b/markdown2-2.5.3.tar.gz", hash = "sha256:4d502953a4633408b0ab3ec503c5d6984d1b14307e32b325ec7d16ea57524895", size = 141676, upload-time = "2025-01-24T21:13:55.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/37/0a13c83ccf5365b8e08ea572dfbc04b8cb87cadd359b2451a567f5248878/markdown2-2.5.3-py3-none-any.whl", hash = "sha256:a8ebb7e84b8519c37bf7382b3db600f1798a22c245bfd754a1f87ca8d7ea63b3", size = 48550, upload-time = "2025-01-24T21:13:49.937Z" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "latex2mathml" },
+    { name = "pygments" },
+    { name = "wavedrom" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/38/13c2f1abae94d5ea0354e146b95a1be9b2137a0d506728e0da037c4276f6/mypy-1.16.0.tar.gz", hash = "sha256:84b94283f817e2aa6350a14b4a8fb2a35a53c286f97c9d30f53b63620e7af8ab", size = 3323139, upload-time = "2025-05-29T13:46:12.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/9c/ca03bdbefbaa03b264b9318a98950a9c683e06472226b55472f96ebbc53d/mypy-1.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a9e056237c89f1587a3be1a3a70a06a698d25e2479b9a2f57325ddaaffc3567b", size = 11059753, upload-time = "2025-05-29T13:18:18.167Z" },
+    { url = "https://files.pythonhosted.org/packages/36/92/79a969b8302cfe316027c88f7dc6fee70129490a370b3f6eb11d777749d0/mypy-1.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0b07e107affb9ee6ce1f342c07f51552d126c32cd62955f59a7db94a51ad12c0", size = 10073338, upload-time = "2025-05-29T13:19:48.079Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9b/a943f09319167da0552d5cd722104096a9c99270719b1afeea60d11610aa/mypy-1.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6fb60cbd85dc65d4d63d37cb5c86f4e3a301ec605f606ae3a9173e5cf34997b", size = 11827764, upload-time = "2025-05-29T13:46:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/ff75e71c65a0cb6ee737287c7913ea155845a556c64144c65b811afdb9c7/mypy-1.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7e32297a437cc915599e0578fa6bc68ae6a8dc059c9e009c628e1c47f91495d", size = 12701356, upload-time = "2025-05-29T13:35:13.553Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ad/0e93c18987a1182c350f7a5fab70550852f9fabe30ecb63bfbe51b602074/mypy-1.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:afe420c9380ccec31e744e8baff0d406c846683681025db3531b32db56962d52", size = 12900745, upload-time = "2025-05-29T13:17:24.409Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5d/036c278d7a013e97e33f08c047fe5583ab4f1fc47c9a49f985f1cdd2a2d7/mypy-1.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:55f9076c6ce55dd3f8cd0c6fff26a008ca8e5131b89d5ba6d86bd3f47e736eeb", size = 9572200, upload-time = "2025-05-29T13:33:44.92Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a3/6ed10530dec8e0fdc890d81361260c9ef1f5e5c217ad8c9b21ecb2b8366b/mypy-1.16.0-py3-none-any.whl", hash = "sha256:29e1499864a3888bca5c1542f2d7232c6e586295183320caa95758fc84034031", size = 2265773, upload-time = "2025-05-29T13:35:18.762Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "natsort"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575, upload-time = "2023-06-20T04:17:19.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268, upload-time = "2023-06-20T04:17:17.522Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "11.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/cb/bb5c01fcd2a69335b86c22142b2bccfc3464087efb7fd382eee5ffc7fdf7/pillow-11.2.1.tar.gz", hash = "sha256:a64dd61998416367b7ef979b73d3a85853ba9bec4c2925f74e588879a58716b6", size = 47026707, upload-time = "2025-04-12T17:50:03.289Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/9c/447528ee3776e7ab8897fe33697a7ff3f0475bb490c5ac1456a03dc57956/pillow-11.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fdec757fea0b793056419bca3e9932eb2b0ceec90ef4813ea4c1e072c389eb28", size = 3190098, upload-time = "2025-04-12T17:48:23.915Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/09/29d5cd052f7566a63e5b506fac9c60526e9ecc553825551333e1e18a4858/pillow-11.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b0e130705d568e2f43a17bcbe74d90958e8a16263868a12c3e0d9c8162690830", size = 3030166, upload-time = "2025-04-12T17:48:25.738Z" },
+    { url = "https://files.pythonhosted.org/packages/71/5d/446ee132ad35e7600652133f9c2840b4799bbd8e4adba881284860da0a36/pillow-11.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bdb5e09068332578214cadd9c05e3d64d99e0e87591be22a324bdbc18925be0", size = 4408674, upload-time = "2025-04-12T17:48:27.908Z" },
+    { url = "https://files.pythonhosted.org/packages/69/5f/cbe509c0ddf91cc3a03bbacf40e5c2339c4912d16458fcb797bb47bcb269/pillow-11.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d189ba1bebfbc0c0e529159631ec72bb9e9bc041f01ec6d3233d6d82eb823bc1", size = 4496005, upload-time = "2025-04-12T17:48:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b3/dd4338d8fb8a5f312021f2977fb8198a1184893f9b00b02b75d565c33b51/pillow-11.2.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:191955c55d8a712fab8934a42bfefbf99dd0b5875078240943f913bb66d46d9f", size = 4518707, upload-time = "2025-04-12T17:48:31.874Z" },
+    { url = "https://files.pythonhosted.org/packages/13/eb/2552ecebc0b887f539111c2cd241f538b8ff5891b8903dfe672e997529be/pillow-11.2.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ad275964d52e2243430472fc5d2c2334b4fc3ff9c16cb0a19254e25efa03a155", size = 4610008, upload-time = "2025-04-12T17:48:34.422Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d1/924ce51bea494cb6e7959522d69d7b1c7e74f6821d84c63c3dc430cbbf3b/pillow-11.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:750f96efe0597382660d8b53e90dd1dd44568a8edb51cb7f9d5d918b80d4de14", size = 4585420, upload-time = "2025-04-12T17:48:37.641Z" },
+    { url = "https://files.pythonhosted.org/packages/43/ab/8f81312d255d713b99ca37479a4cb4b0f48195e530cdc1611990eb8fd04b/pillow-11.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fe15238d3798788d00716637b3d4e7bb6bde18b26e5d08335a96e88564a36b6b", size = 4667655, upload-time = "2025-04-12T17:48:39.652Z" },
+    { url = "https://files.pythonhosted.org/packages/94/86/8f2e9d2dc3d308dfd137a07fe1cc478df0a23d42a6c4093b087e738e4827/pillow-11.2.1-cp313-cp313-win32.whl", hash = "sha256:3fe735ced9a607fee4f481423a9c36701a39719252a9bb251679635f99d0f7d2", size = 2332329, upload-time = "2025-04-12T17:48:41.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ec/1179083b8d6067a613e4d595359b5fdea65d0a3b7ad623fee906e1b3c4d2/pillow-11.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:74ee3d7ecb3f3c05459ba95eed5efa28d6092d751ce9bf20e3e253a4e497e691", size = 2676388, upload-time = "2025-04-12T17:48:43.625Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f1/2fc1e1e294de897df39fa8622d829b8828ddad938b0eaea256d65b84dd72/pillow-11.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:5119225c622403afb4b44bad4c1ca6c1f98eed79db8d3bc6e4e160fc6339d66c", size = 2414950, upload-time = "2025-04-12T17:48:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3e/c328c48b3f0ead7bab765a84b4977acb29f101d10e4ef57a5e3400447c03/pillow-11.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8ce2e8411c7aaef53e6bb29fe98f28cd4fbd9a1d9be2eeea434331aac0536b22", size = 3192759, upload-time = "2025-04-12T17:48:47.866Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0e/1c68532d833fc8b9f404d3a642991441d9058eccd5606eab31617f29b6d4/pillow-11.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ee66787e095127116d91dea2143db65c7bb1e232f617aa5957c0d9d2a3f23a7", size = 3033284, upload-time = "2025-04-12T17:48:50.189Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/cb/6faf3fb1e7705fd2db74e070f3bf6f88693601b0ed8e81049a8266de4754/pillow-11.2.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9622e3b6c1d8b551b6e6f21873bdcc55762b4b2126633014cea1803368a9aa16", size = 4445826, upload-time = "2025-04-12T17:48:52.346Z" },
+    { url = "https://files.pythonhosted.org/packages/07/94/8be03d50b70ca47fb434a358919d6a8d6580f282bbb7af7e4aa40103461d/pillow-11.2.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63b5dff3a68f371ea06025a1a6966c9a1e1ee452fc8020c2cd0ea41b83e9037b", size = 4527329, upload-time = "2025-04-12T17:48:54.403Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a4/bfe78777076dc405e3bd2080bc32da5ab3945b5a25dc5d8acaa9de64a162/pillow-11.2.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:31df6e2d3d8fc99f993fd253e97fae451a8db2e7207acf97859732273e108406", size = 4549049, upload-time = "2025-04-12T17:48:56.383Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4d/eaf9068dc687c24979e977ce5677e253624bd8b616b286f543f0c1b91662/pillow-11.2.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:062b7a42d672c45a70fa1f8b43d1d38ff76b63421cbbe7f88146b39e8a558d91", size = 4635408, upload-time = "2025-04-12T17:48:58.782Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/26/0fd443365d9c63bc79feb219f97d935cd4b93af28353cba78d8e77b61719/pillow-11.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4eb92eca2711ef8be42fd3f67533765d9fd043b8c80db204f16c8ea62ee1a751", size = 4614863, upload-time = "2025-04-12T17:49:00.709Z" },
+    { url = "https://files.pythonhosted.org/packages/49/65/dca4d2506be482c2c6641cacdba5c602bc76d8ceb618fd37de855653a419/pillow-11.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f91ebf30830a48c825590aede79376cb40f110b387c17ee9bd59932c961044f9", size = 4692938, upload-time = "2025-04-12T17:49:02.946Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/92/1ca0c3f09233bd7decf8f7105a1c4e3162fb9142128c74adad0fb361b7eb/pillow-11.2.1-cp313-cp313t-win32.whl", hash = "sha256:e0b55f27f584ed623221cfe995c912c61606be8513bfa0e07d2c674b4516d9dd", size = 2335774, upload-time = "2025-04-12T17:49:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ac/77525347cb43b83ae905ffe257bbe2cc6fd23acb9796639a1f56aa59d191/pillow-11.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:36d6b82164c39ce5482f649b437382c0fb2395eabc1e2b1702a6deb8ad647d6e", size = 2681895, upload-time = "2025-04-12T17:49:06.635Z" },
+    { url = "https://files.pythonhosted.org/packages/67/32/32dc030cfa91ca0fc52baebbba2e009bb001122a1daa8b6a79ad830b38d3/pillow-11.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:225c832a13326e34f212d2072982bb1adb210e0cc0b153e688743018c94a2681", size = 2417234, upload-time = "2025-04-12T17:49:08.399Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857, upload-time = "2025-04-05T14:07:51.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841, upload-time = "2025-04-05T14:07:49.641Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
+]
+
+[[package]]
+name = "python-magic"
+version = "0.4.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b", size = 14677, upload-time = "2022-06-07T20:16:59.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3", size = 13840, upload-time = "2022-06-07T20:16:57.763Z" },
+]
+
+[[package]]
+name = "python-magic-bin"
+version = "0.4.14"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/5d/10b9ac745d9fd2f7151a2ab901e6bb6983dbd70e87c71111f54859d1ca2e/python_magic_bin-0.4.14-py2.py3-none-win32.whl", hash = "sha256:34a788c03adde7608028203e2dbb208f1f62225ad91518787ae26d603ae68892", size = 397784, upload-time = "2017-10-02T16:30:15.806Z" },
+    { url = "https://files.pythonhosted.org/packages/07/c2/094e3d62b906d952537196603a23aec4bcd7c6126bf80eb14e6f9f4be3a2/python_magic_bin-0.4.14-py2.py3-none-win_amd64.whl", hash = "sha256:90be6206ad31071a36065a2fc169c5afb5e0355cbe6030e87641c6c62edc2b69", size = 409299, upload-time = "2017-10-02T16:30:18.545Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload-time = "2024-05-29T15:37:47.027Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418, upload-time = "2025-04-20T18:50:08.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677, upload-time = "2025-04-20T18:50:07.196Z" },
+]
+
+[[package]]
+name = "svgwrite"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/c1/263d4e93b543390d86d8eb4fc23d9ce8a8d6efd146f9427364109004fa9b/svgwrite-1.4.3.zip", hash = "sha256:a8fbdfd4443302a6619a7f76bc937fc683daf2628d9b737c891ec08b8ce524c3", size = 189516, upload-time = "2022-07-14T14:05:26.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/15/640e399579024a6875918839454025bb1d5f850bb70d96a11eabb644d11c/svgwrite-1.4.3-py3-none-any.whl", hash = "sha256:bb6b2b5450f1edbfa597d924f9ac2dd099e625562e492021d7dd614f65f8a22d", size = 67122, upload-time = "2022-07-14T14:05:24.459Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "trilium-py"
+source = { editable = "." }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "click" },
+    { name = "loguru" },
+    { name = "markdown2", extra = ["all"] },
+    { name = "natsort" },
+    { name = "pillow" },
+    { name = "python-dateutil" },
+    { name = "python-dotenv" },
+    { name = "python-magic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-magic-bin", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tqdm" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "black" },
+    { name = "isort" },
+    { name = "mypy" },
+    { name = "pytest" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "beautifulsoup4" },
+    { name = "black", marker = "extra == 'dev'" },
+    { name = "click" },
+    { name = "isort", marker = "extra == 'dev'" },
+    { name = "loguru" },
+    { name = "markdown2", extras = ["all"] },
+    { name = "mypy", marker = "extra == 'dev'" },
+    { name = "natsort" },
+    { name = "pillow" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'test'" },
+    { name = "pytest-cov", marker = "extra == 'test'" },
+    { name = "python-dateutil" },
+    { name = "python-dotenv" },
+    { name = "python-magic", marker = "sys_platform == 'darwin'" },
+    { name = "python-magic", marker = "sys_platform == 'linux'" },
+    { name = "python-magic-bin", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tqdm" },
+]
+provides-extras = ["dev", "test"]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload-time = "2025-04-10T15:23:39.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload-time = "2025-04-10T15:23:37.377Z" },
+]
+
+[[package]]
+name = "wavedrom"
+version = "2.0.3.post3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "six" },
+    { name = "svgwrite" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/71/6739e3abac630540aaeaaece4584c39f88b5f8658ce6ca517efec455e3de/wavedrom-2.0.3.post3.tar.gz", hash = "sha256:327b4d5dca593c81257c202fea516f7a908747fb11527c359f034f5b7af7f47b", size = 137737, upload-time = "2022-05-27T11:53:09.675Z" }
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]


### PR DESCRIPTION
Hi Nate,
This is an experimental command line interface for trilium-py. I prototyped this as a standalone wrapper first, [trilium-py-cli][tpy]. That seemed promising, so I created this branch in my trilium-py fork to see if it could be merged into the main repository.

uv managed install works, regular pip install doesn't. I don't know why yet.

I use [`uv`][uv] from Astral to manage python environments and packages, which uses the newer `pyproject.toml` format, while trilium-py uses the older `setup.py` format. I don't understand setup.py well, and I haven't been able to get the cli script installed using the standard `pip install .` The library installs fine but not the cli script.

See **README-CLI.md** in project root for the install path that works for me, and example usage instructions.

If this is something that interests you, I'll keep trying to understand and solve installing without uv, and extending it to work with more of the main library. If this isn't something that you see fitting inside trilium-py I'll focus on the standalone wrapper. 

No matter what you decide, any and all feedback is welcome! I'll be away from computers untill the end of June, so won't be responding in any detail before then.

[tpy]: https://github.com/maphew/trilium-py-cli
[uv]: https://astral.sh/uv